### PR TITLE
Added work around to manually add etag/last-modified headers based on build version to static resources

### DIFF
--- a/generators/app/templates/server/package.json
+++ b/generators/app/templates/server/package.json
@@ -16,7 +16,7 @@
     "test": "jest",
     "test:cov": "jest --coverage",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "build": "rm -rf public && npm run lint && npm run test && npm run --prefix ../client build && npm run compile:prod",
+    "build": "rm -rf public && npm run generate-build-version && npm run lint && npm run test && npm run --prefix ../client build && npm run compile:prod",
     "deploy:dev": "CLOUDSDK_CORE_PROJECT=<%= slugify(project) %>-dev npm run deploy && TAG_NAME=dev/`date +%Y%m%d_%H%M%S` && git tag -a $TAG_NAME -m 'dev deployed' && git push origin $TAG_NAME",
     "deploy:uat": "CLOUDSDK_CORE_PROJECT=<%= slugify(project) %>-uat npm run deploy && TAG_NAME=uat/`date +%Y%m%d_%H%M%S` && git tag -a $TAG_NAME -m 'uat deployed' && git push origin $TAG_NAME",
     "deploy:prod": "CLOUDSDK_CORE_PROJECT=<%= slugify(project) %>-prod npm run deploy && TAG_NAME=prod/`date +%Y%m%d_%H%M%S` && git tag -a $TAG_NAME -m 'prod deployed' && git push origin $TAG_NAME",
@@ -24,7 +24,8 @@
     "dsui": "dsui --port 4000",
     "kill": "bash ./scripts/kill.sh",
     "kill-force": "bash ./scripts/kill.sh -9",
-    "clear-datastore": "rm -rf ~/.config/gcloud/emulators/datastore"
+    "clear-datastore": "rm -rf ~/.config/gcloud/emulators/datastore",
+    "generate-build-version": "node ./scripts/buildVersionGenerator.js"
   },
   "dependencies": {
     "@google-cloud/debug-agent": "4.2.2",

--- a/generators/app/templates/server/scripts/buildVersionGenerator.js
+++ b/generators/app/templates/server/scripts/buildVersionGenerator.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+
+const version = Date.now();
+let body = {
+  version
+};
+
+console.log(`New build version: ${version}`);
+let data = JSON.stringify(body, null, 2);
+
+fs.writeFileSync('./buildinfo.json', data, err => {
+  if (err) throw err;
+});

--- a/generators/app/templates/server/src/app.module.ts
+++ b/generators/app/templates/server/src/app.module.ts
@@ -1,9 +1,11 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, RequestMethod } from '@nestjs/common';
 import { GCloudModule } from '@mondomob/gae-node-nestjs';
 import { ConfigurationModule } from './config/config.module';
 import { UserModule } from './users/users.module';
 import { MigrationModule } from './migrations/migrations.module';
 import { AttachmentsModule } from './attachments/attachments.module';
+import { BuildVersionMiddleware } from './util/buildVersion.middleware';
+import { CacheHeadersMiddleware } from './util/cacheHeaders.middleware';
 
 @Module({
   imports: [
@@ -17,4 +19,13 @@ import { AttachmentsModule } from './attachments/attachments.module';
     AttachmentsModule,
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(BuildVersionMiddleware)
+        .forRoutes({ path: '*', method: RequestMethod.ALL })
+      .apply(CacheHeadersMiddleware)
+        .exclude('(api|tasks|system)/(.*)')
+        .forRoutes({ path: '*', method: RequestMethod.GET });
+  }
+}

--- a/generators/app/templates/server/src/util/buildVersion.middleware.ts
+++ b/generators/app/templates/server/src/util/buildVersion.middleware.ts
@@ -1,0 +1,18 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { getBuildInfo } from './buildVersionUtils';
+
+@Injectable()
+export class BuildVersionMiddleware implements NestMiddleware {
+  buildTs: number | undefined;
+
+  constructor() {
+    this.buildTs = getBuildInfo()?.version;
+  }
+
+  // tslint:disable-next-line:ban-types
+  use(req: Request, res: Response, next: Function) {
+    res.setHeader('build-time', this.buildTs || '0');
+    next();
+  }
+}

--- a/generators/app/templates/server/src/util/buildVersionUtils.ts
+++ b/generators/app/templates/server/src/util/buildVersionUtils.ts
@@ -1,0 +1,14 @@
+import * as fs from 'fs';
+
+const buildInfoFile = './buildinfo.json';
+
+export interface BuildInfo {
+  version: number;
+}
+
+export const getBuildInfo = (): BuildInfo | undefined => {
+  if (fs.existsSync(buildInfoFile)) {
+    const rawdata: any = fs.readFileSync(buildInfoFile);
+    return JSON.parse(rawdata);
+  }
+};

--- a/generators/app/templates/server/src/util/cacheHeaders.middleware.ts
+++ b/generators/app/templates/server/src/util/cacheHeaders.middleware.ts
@@ -1,0 +1,35 @@
+import { createLogger, Logger } from '@mondomob/gae-node-nestjs';
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { getBuildInfo } from './buildVersionUtils';
+
+/**
+ * Due to an issue with expressjs not adding correct etags to static files, this
+ * is a work around to manually add etag/last-modified headers based on build version
+ */
+@Injectable()
+export class CacheHeadersMiddleware implements NestMiddleware {
+  buildTs: number | undefined;
+  logger: Logger;
+
+  constructor() {
+    this.logger = createLogger('cache-headers-middleware');
+
+    this.buildTs = getBuildInfo()?.version;
+  }
+
+  // tslint:disable-next-line:ban-types
+  use(req: Request, res: Response, next: Function) {
+    next();
+
+    if (this.buildTs && req.headers.accept && req.headers.accept.includes('text/html')) {
+      const etag = `W/"${this.buildTs}"`;
+      const lastModified = new Date(Number(this.buildTs)).toUTCString();
+
+      this.logger.info(`Setting etag: ${etag}, last-modified: ${lastModified} headers for path ${req.originalUrl}`);
+
+      res.setHeader('etag', etag);
+      res.setHeader('last-modified', lastModified);
+    }
+  }
+}


### PR DESCRIPTION
Currently when open the application sometimes it appears the old version of the code is being loaded.

Looks like an issue with the ETag not being set correctly.
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag for overview of how they're used for caching.

Express always returns a 'weak' ETag for static files. See https://expressjs.com/en/4x/api.html#express.static
When the client is built all the contents go into the static public folder. The index.html always includes the import scripts for the CSS and Javascript that we write, and what we included as library imports.
The CSS / JS is imported in the index.html with lines like:
```
<script src="/static/js/runtime-main.500c68b8.js"></script>
<script src="/static/js/2.ef2565ab.chunk.js"></script>
<script src="/static/js/main.45166089.chunk.js"></script>
```
Each new build will have different chunk files assuming we've changed the code in any way.
Unfortunately the weak ETag is not necessarily changing even though the chunk files are changing.
The server sending back the wrong etag makes the browser think it has the correct version of index.html already. However the browsers cached version has links to the wrong (old) chunk files, and therefore loads old CSS/JS if it has those files cached already.
In my testing, the server returns etag: W/"344-49773873e8" for the following two different index.html files:

`<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/><meta name="theme-color" content="#000000"/><link rel="manifest" href="/manifest.json" crossorigin="use-credentials"/><link rel="shortcut icon" href="/favicon.ico"/><link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/><title>Sargon Pay</title><link href="/static/css/2.5ebe26fd.chunk.css" rel="stylesheet"><link href="/static/css/main.3fc00b3a.chunk.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div><script src="/static/js/runtime-main.500c68b8.js"></script><script src="/static/js/2.160274fa.chunk.js"></script><script src="/static/js/main.9e004706.chunk.js"></script></body></html>`

`<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"/><meta name="theme-color" content="#000000"/><link rel="manifest" href="/manifest.json" crossorigin="use-credentials"/><link rel="shortcut icon" href="/favicon.ico"/><link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"/><title>Sargon Pay</title><link href="/static/css/2.5ebe26fd.chunk.css" rel="stylesheet"><link href="/static/css/main.3fc00b3a.chunk.css" rel="stylesheet"></head><body><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div><script src="/static/js/runtime-main.500c68b8.js"></script><script src="/static/js/2.cab70b7e.chunk.js"></script><script src="/static/js/main.c88244e0.chunk.js"></script></body></html>`

Apparently Express Static always returns weak eTags the same way that Apache does (See expressjs/expressjs.com: Issue #600) , which is a combination of file size (bytes) and file timestamp (ms) (see https://stackoverflow.com/questions/47512043/how-etags-are-generated-and-configured)

Apache/2.4: "417-59b782a99f493" i.e. "hex(Size)-hex(MTime in nanoseconds)"
So the issue is that index.html has the same size and timestamp. Size is understandable because as the chunk ids change they'll be the same size in bytes. However the file timestamp should change with each new build. This could be an GAE thing.